### PR TITLE
_otter_env_core.sh: do not clobber existing PERL5LIB

### DIFF
--- a/software/anacode/otter/otter_live/bin/_otter_env_core.sh
+++ b/software/anacode/otter/otter_live/bin/_otter_env_core.sh
@@ -143,7 +143,7 @@ $ensembl_otter_home/modules:\
 $ensembl_home/ensembl/modules:\
 $otter_lib_perl5:\
 $ensembl_otter_home/tk\
-"
+${PERL5LIB:+:${PERL5LIB}}"
 
 osname="$( uname -s )"
 

--- a/software/anacode/otter/otter_rel109/bin/_otter_env_core.sh
+++ b/software/anacode/otter/otter_rel109/bin/_otter_env_core.sh
@@ -129,7 +129,7 @@ $ensembl_otter_home/modules:\
 $ensembl_home/ensembl/modules:\
 $otter_lib_perl5:\
 $ensembl_otter_home/tk:\
-" 
+${PERL5LIB:+:${PERL5LIB}}"
 #Edit 3-4 /usr/local/lib/perl5/5.18.2:\
 #/usr/local/lib/perl5/5.18.2/x86_64-linux\
 #/usr/lib/x86_64-linux-gnu/perl/5.22/:\


### PR DESCRIPTION
As _otter_env_core.sh_ in both _otter_live_ and _otter_rel109_ (as well as in the _ensembl-otter_ repo; see the relevant PR there) stands, running _otter_ overwrites whatever might have been present in $PERL5LIB. This is a problem _e.g._ if one uses this variable to make Perl aware of the install directory used by cpanminus. This PR ensures that the original value of PERL5LIB is preserved.
