### PR TITLE
use path of script, not of terminal

### DIFF
--- a/software/anacode/otter/otter_live/bin/_otter_env_core.sh
+++ b/software/anacode/otter/otter_live/bin/_otter_env_core.sh
@@ -13,8 +13,8 @@
 # OTTER_LIB_PERL5_DEV      to override the location of other perl modules (Zircon).
 
 version="109"
-var=$PWD 
-anasoft="${var}/../../../../../software/anacode" 
+var=`dirname $(readlink -f $0)`
+anasoft="${var}/../../../../../software/anacode"
 OTTER_HOME="${var}/../../../../../software/anacode/otter/otter_rel109" #Editing this line to call 109 version
 otter_perl="/usr/bin"
 


### PR DESCRIPTION
Just an annoyance...
to start otter one currently has to be in `otter-client/software/anacode/otter/otter_live/bin/`
otherwise paths will not be set properly, because they rely on `pwd`.

This changes that to rely on the actual run path, so that you can run it from wherever...

